### PR TITLE
Remove interfaces, types and collections from controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Com a aplicação executando, abra o arquivo **index.html** para poder realizar 
 
 * **public/index.html**: Arquivo html com uma interface para testes rápidos e visuais;
 
+* **src/collections/**: Coleções de objetos com determinados comportamentos;
+
 * **src/controllers/**: Validações de parâmetros de requisição e execução de lógicas, enviando resposta com o código correto;
+
+* **src/core/**: Constantes e interfaces da API;
 
 * **src/routes/**: Mapeamento de rotas para as *controllers*;
 

--- a/src/collections/pieces.ts
+++ b/src/collections/pieces.ts
@@ -1,0 +1,27 @@
+import { Piece } from '../core/interfaces'
+
+// pieces described
+const pieces: { [key: string]: Piece } = {
+  horse: {
+    possibleMoves: [{ x: 2, y: 1 }, { x: 1, y: 2 }],
+    multipleMoves: false
+  // },
+  // knight: {
+  //   possibleMoves: [{ x: 1, y: 0 }, { x: 0, y: 1 }],
+  //   multipleMoves: true
+  // },
+  // bishop: {
+  //   possibleMoves: [{ x: 1, y: 1 }],
+  //   multipleMoves: true
+  // },
+  // queen: {
+  //   possibleMoves: [{ x: 1, y: 1 }, { x: 1, y: 0 }, { x: 0, y: 1 }],
+  //   multipleMoves: true
+  // },
+  // king: {
+  //   possibleMoves: [{ x: 1, y: 1 }, { x: 1, y: 0 }, { x: 0, y: 1 }],
+  //   multipleMoves: false
+  }
+}
+
+export default pieces;

--- a/src/controllers/PositionsController.ts
+++ b/src/controllers/PositionsController.ts
@@ -1,56 +1,15 @@
-// Numeric indexes for piece position
-interface NumericPosition {
-  x: number,
-  y: number
-}
-
-interface Piece {
-  // possible dx and dy for the piece in one move
-  possibleMoves: NumericPosition[],
-  // indicates if the piece can perform the possible moves multiples times (typically used for queens, bishops...)
-  multipleMoves: boolean,
-  // the fields below are necessary only if pawns are considered
-  // strictMoves: boolean, // indicates if the piece must move strictly in the moves provided, without changing signs
-  // attackMoves: NumericPosition[], // move that piece can do only if there is an enemy there
-  // firstMove: boolean // indicates if it is the first move of the piece (pawns can move 2 times then)
-}
-
-const charCodeAtA = 'A'.charCodeAt(0); // Char code at uppercase A, first valid column
-// sigInverters allows the piece to move in different directions invertings possibleMoves signs
-const signInverters = [{ x: 1, y: 1 }, { x: 1, y: -1 }, { x: -1, y: 1 }, { x: -1, y: -1 }]
+import pieces from '../collections/pieces';
+import { NumericPosition, Piece } from '../core/interfaces';
+import { charCodeAtA, signInverters } from '../core/constants';
 
 export class PositionsController {
-  // pieces described
-  private pieces: { [key: string]: Piece } = {
-    horse: {
-      possibleMoves: [{ x: 2, y: 1 }, { x: 1, y: 2 }],
-      multipleMoves: false
-    // },
-    // knight: {
-    //   possibleMoves: [{ x: 1, y: 0 }, { x: 0, y: 1 }],
-    //   multipleMoves: true
-    // },
-    // bishop: {
-    //   possibleMoves: [{ x: 1, y: 1 }],
-    //   multipleMoves: true
-    // },
-    // queen: {
-    //   possibleMoves: [{ x: 1, y: 1 }, { x: 1, y: 0 }, { x: 0, y: 1 }],
-    //   multipleMoves: true
-    // },
-    // king: {
-    //   possibleMoves: [{ x: 1, y: 1 }, { x: 1, y: 0 }, { x: 0, y: 1 }],
-    //   multipleMoves: false
-    }
-  }
-
   /** Get possible next positions for the piece received */
   public getNextPositions(pieceName: string, position: string): { status: number, [key: string]: any } {
     try {
       const pos = this.validateConvertPosition(position)
       if (!pos) return { status: 400, error: 'invalid-position' };
 
-      const piece = this.pieces[pieceName]
+      const piece = pieces[pieceName]
       if (!piece) return { status: 400, error: 'invalid-piece' };
 
       return { status: 200, data: this.calculateNextPositions(piece, pos) };

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,4 @@
+export const charCodeAtA = 'A'.charCodeAt(0); // Char code at uppercase A, first valid column
+
+// signInverters allows the piece to move in different directions invertings possibleMoves signs
+export const signInverters = [{ x: 1, y: 1 }, { x: 1, y: -1 }, { x: -1, y: 1 }, { x: -1, y: -1 }]

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,0 +1,16 @@
+// Numeric indexes for piece position
+export interface NumericPosition {
+  x: number,
+  y: number
+}
+
+export interface Piece {
+  // possible dx and dy for the piece in one move
+  possibleMoves: NumericPosition[],
+  // indicates if the piece can perform the possible moves multiples times (typically used for queens, bishops...)
+  multipleMoves: boolean,
+  // the fields below are necessary only if pawns are considered
+  // strictMoves: boolean, // indicates if the piece must move strictly in the moves provided, without changing signs
+  // attackMoves: NumericPosition[], // move that piece can do only if there is an enemy there
+  // firstMove: boolean // indicates if it is the first move of the piece (pawns can move 2 times then)
+}


### PR DESCRIPTION
## Descrição

Devido a grande concentração de interfaces, constantes e coleções em **controller/PositionsController**, as mesmas foram separadas em diferentes arquivos.

## Testes

A execução seguiu ocorrendo sem problemas:

![image](https://user-images.githubusercontent.com/44649580/89113084-99b61b00-d442-11ea-8ac6-8b9c52eb615f.png)
![image](https://user-images.githubusercontent.com/44649580/89113093-aa669100-d442-11ea-9509-b935e8e0b73d.png)
![image](https://user-images.githubusercontent.com/44649580/89113101-c5d19c00-d442-11ea-9bd6-f5e2f7834c36.png)