### PR TITLE
Adiciona movimentos de peões criando novas propriedades

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,5 @@ Após realizade o *merge*, será criada uma tag com o mesmo número descrito no 
 
 ## Próximos Passos
 
-- Para calcular o movimento de peões, diferentes situações devem ser consideradas, pois os mesmos possuem movimento estrito para frente, podendo se movimentar duas casas para frente se for seu primeiro movimento, enquanto que o ataque à outras peças só pode ser realizado na diagonal (algumas dessas propriedades já estão presentes em forma de comentário em **src/controllers/PositionsController.ts**);
 - Considerar a presença de outras peças no tabuleiro, verificando se as mesmas são aliadas ou inimigas; pois se forem amigas, o movimento é impossível, se forem inimigas, o movimento termina ali eliminando aquela peça (lembrar de considerar o movimento dos peões para ataque);
 - ...

--- a/public/index.html
+++ b/public/index.html
@@ -66,10 +66,12 @@
 </head>
 <body>
   <div id="piece-selector">
-    <input type="radio" id="horse" name="piece" value="horse" checked>
-    <label for="horse">Cavalo</label><br>
+    <input type="radio" id="pawn" name="piece" value="pawn">
+    <label for="pawn">Peão</label><br>
     <input type="radio" id="knight" name="piece" value="knight">
     <label for="knight">Torre</label><br>
+    <input type="radio" id="horse" name="piece" value="horse" checked>
+    <label for="horse">Cavalo</label><br>
     <input type="radio" id="bishop" name="piece" value="bishop">
     <label for="bishop">Bispo</label> 
     <input type="radio" id="queen" name="piece" value="queen">

--- a/src/app.spec.ts
+++ b/src/app.spec.ts
@@ -132,6 +132,29 @@ describe('King Possible Positions Request', () => {
   });
 });
 
+describe('Pawn Possible Positions Request', () => {
+  const path = '/positions';
+  const pieceName = 'pawn';
+
+  it('Should return the positions for a pawn near the corner on its first move on call', async () => {
+    return chai
+      .request(app)
+      .get(`${path}/${pieceName}&A2`)
+      .then(res => {
+        chai.expect(res.body.data).to.have.members(['A3', 'A4', 'B3']);
+      });
+  });
+
+  it('Should return positions for a pawn in the middle of the table', async () => {
+    return chai
+      .request(app)
+      .get(`${path}/${pieceName}&C4`)
+      .then(res => {
+        chai.expect(res.body.data).to.have.members(['C5', 'B5', 'D5']);
+      });
+  });
+});
+
 describe('Invalid requests', () => {
   const path = '/positions';
 

--- a/src/collections/pieces.ts
+++ b/src/collections/pieces.ts
@@ -21,6 +21,13 @@ const pieces: { [key: string]: Piece } = {
   king: {
     possibleMoves: [{ x: 1, y: 1 }, { x: 1, y: 0 }, { x: 0, y: 1 }],
     multipleMoves: false
+  },
+  pawn: {
+    possibleMoves: [{ x: 0, y: 1 }],
+    multipleMoves: false,
+    strictMoves: true,
+    attackMoves: [{ x: 1, y: 1 }, { x: -1, y: 1 }],
+    duplicateFirstMove: true
   }
 }
 

--- a/src/controllers/PositionsController.ts
+++ b/src/controllers/PositionsController.ts
@@ -26,9 +26,8 @@ export class PositionsController {
     piece.possibleMoves.forEach(possibleMove => {
       let nextPosNumeric: NumericPosition;
 
-      // if a piece with strictMoves is considered, this loop should have only 1 iteration:
-      // let numDirections = (piece.strictMoves ? 1 : signInverters.length)
-      for (let i = 0; i < signInverters.length; i++) {
+      let numDirections = (piece.strictMoves ? 1 : signInverters.length)
+      for (let i = 0; i < numDirections; i++) {
         // It is not necessary to calculate inverted signs for 0 move values
         if ((signInverters[i].x === -1 && possibleMove.x === 0) ||
           (signInverters[i].y === -1 && possibleMove.y === 0)) {
@@ -46,9 +45,21 @@ export class PositionsController {
 
           if (this.isWithinTable(nextPosNumeric)) {
             nextPositions.push(this.convertToChessNotation(nextPosNumeric));
+
             if (piece.multipleMoves) {
               // Possible multiple moves, so calculate the next one based on the position got now
               currentPos = nextPosNumeric;
+            } else if (piece.duplicateFirstMove && pos.y === 1) {
+              // First pawn move
+              currentPos = nextPosNumeric;
+
+              nextPosNumeric = {
+                x: currentPos.x + possibleMove.x,
+                y: currentPos.y + possibleMove.y
+              };
+
+              nextPositions.push(this.convertToChessNotation(nextPosNumeric));
+              break;
             } else {
               break; // Only one move is possible, break
             }
@@ -57,6 +68,17 @@ export class PositionsController {
           }
         }
       }
+    })
+
+    // Verify possible positions exclusive to attack enemies
+    if (piece.attackMoves) piece.attackMoves.forEach(attackMove => {
+      const nextPosNumeric = {
+        x: pos.x + attackMove.x,
+        y: pos.y + attackMove.y
+      };
+
+      // There should be a verification for enemies at the position also
+      if (this.isWithinTable(nextPosNumeric)) nextPositions.push(this.convertToChessNotation(nextPosNumeric));
     })
 
     return nextPositions;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -10,7 +10,7 @@ export interface Piece {
   // indicates if the piece can perform the possible moves multiples times (typically used for queens, bishops...)
   multipleMoves: boolean,
   // the fields below are necessary only if pawns are considered
-  // strictMoves: boolean, // indicates if the piece must move strictly in the moves provided, without changing signs
-  // attackMoves: NumericPosition[], // move that piece can do only if there is an enemy there
-  // firstMove: boolean // indicates if it is the first move of the piece (pawns can move 2 times then)
+  strictMoves?: boolean, // indicates if the piece must move strictly in the moves provided, without changing signs
+  duplicateFirstMove?: boolean // possible first move of the piece (pawns can move 2 times then)
+  attackMoves?: NumericPosition[], // possible moves only if there is an enemy there
 }


### PR DESCRIPTION
## Descrição

Cria peça do peão e adiciona novos atributos à *collection* de peças para lidar com os diferentes padrões:

- **strictMoves**: indica se peça pode se mover somente no sentido positivo das direções definidas, sem inverter os sinais dos movimentos;
- **attackMoves**: movimentos possíveis somente se houver uma peça adversário no caminho, esses movimentos não são múltiplos e são estritos;
- **duplicateFirstMove**: indica se peça pode duplicar o primeiro movimento.

Diferente da solução apresentada em !9, esse *pull request* torna o peão uma peça como as demais (adiciona na interface `pieces`), com propriedades adicionais para descrever seus comportamentos singulares. O cálculo de seus movimentos é realizado na mesma função que as demais peças, que agora considera os movimentos de ataque e a duplicação de movimentos.

Devido ao fato de ainda não ser considerada a presença de outras peças no tabuleiro, os movimentos de ataque não estão fazendo essa verificação.

## Testes

![image](https://user-images.githubusercontent.com/44649580/104830453-0345ac80-585e-11eb-834a-00ca0d9de512.png)
![image](https://user-images.githubusercontent.com/44649580/104830457-09d42400-585e-11eb-8a7c-13040c923bb3.png)
